### PR TITLE
fix "could not identify document class"

### DIFF
--- a/_extensions/sagej/sagej_template.tex
+++ b/_extensions/sagej/sagej_template.tex
@@ -7,7 +7,7 @@ $endif$
 $if(CJKmainfont)$
 \PassOptionsToPackage{space}{xeCJK}
 $endif$
-\documentclass[ $if(fontsize)$$fontsize$, $endif$ $if(papersize)$$papersize$paper, $endif$ $for(classoption)$$classoption$$sep$, $endfor$ ]{sagej}
+\documentclass[$if(fontsize)$$fontsize$,$endif$$if(papersize)$$papersize$paper, $endif$$for(classoption)$$classoption$$sep$,$endfor$]{sagej}
 \usepackage{amsmath,amssymb}
 $if(linestretch)$
 \usepackage{setspace}

--- a/_extensions/sagej/sagej_template.tex
+++ b/_extensions/sagej/sagej_template.tex
@@ -7,18 +7,7 @@ $endif$
 $if(CJKmainfont)$
 \PassOptionsToPackage{space}{xeCJK}
 $endif$
-%
-\documentclass[
-$if(fontsize)$
-  $fontsize$,
-$endif$
-$if(papersize)$
-  $papersize$paper,
-$endif$
-$for(classoption)$
-  $classoption$$sep$,
-$endfor$
-]{sagej}
+\documentclass[ $if(fontsize)$$fontsize$, $endif$ $if(papersize)$$papersize$paper, $endif$ $for(classoption)$$classoption$$sep$, $endfor$ ]{sagej}
 \usepackage{amsmath,amssymb}
 $if(linestretch)$
 \usepackage{setspace}


### PR DESCRIPTION
When document class contains line breaks, it prevents the word count feature from working properly in ShareLaTeX/Overleaf. So this PR suggests to sacrifice the readability of one line in the template for better compatibility and user experience.

Here is the error you would get for word count in ShareLaTeX/Overleaf if the code is like
```latex
\documentclass[
    Crown,
    times,
    sageh]{sagej}
```
<img width="694" height="358" alt="Screenshot 2025-09-20 at 17 31 18" src="https://github.com/user-attachments/assets/32fa4213-97df-4ebd-b007-117aa8db6781" />

This PR results in the code being single line:
```latex
\documentclass[Crown,times,sageh]{sagej}
```

This makes the word count happy.